### PR TITLE
fix: mixed geometries

### DIFF
--- a/src/polygonParts/models/polygonPartsManager.ts
+++ b/src/polygonParts/models/polygonPartsManager.ts
@@ -492,7 +492,7 @@ export class PolygonPartsManager {
 
     const filterGeometriesCTE = entityManager
       .createQueryBuilder()
-      .select('st_geomfromgeojson(geometry)', 'filter_geometry')
+      .select('st_setsrid(st_geomfromgeojson(geometry), 4326)', 'filter_geometry')
       .addSelect('properties')
       .addSelect('id', 'filter_id')
       .from('input_filter_geometries', 'input_filter_geometries');
@@ -684,7 +684,7 @@ export class PolygonPartsManager {
     const geometriesCollection = geometryCollection(filterGeometries).geometry;
     const isValidFilterGeometry = (
       await entityManager.query<IsValidDetailsResult[]>(
-        `select ${isValidDetailsResult.valid}, ${isValidDetailsResult.reason}, st_asgeojson(location) as ${isValidDetailsResult.location} from st_isvaliddetail(st_geomfromgeojson($1))`,
+        `select ${isValidDetailsResult.valid}, ${isValidDetailsResult.reason}, st_asgeojson(location) as ${isValidDetailsResult.location} from st_isvaliddetail(st_setsrid(st_geomfromgeojson($1), 4326))`,
         [JSON.stringify(geometriesCollection)]
       )
     )[0];


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

fix mixed geometries SRID error happening in version 2.5 of PostGIS when parsing geojson using `st_geomfromgeojson()`. geometries are parsed with SRID 0 by default in this version. this causes the thrown error later in `st_intersection()`