### PR TITLE
fix: ingestion date of existing polygon parts changes after updating a new part (MAPCO-7910)

### DIFF
--- a/src/db/migrations/1749550991995-ModifyPolygonPartsCalculationStoredProcedure.ts
+++ b/src/db/migrations/1749550991995-ModifyPolygonPartsCalculationStoredProcedure.ts
@@ -3,6 +3,8 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 export class ModifyPolygonPartsCalculationStoredProcedure1749550991995 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP PROCEDURE IF EXISTS polygon_parts.update_polygon_parts(regclass, regclass)`);
+
         await queryRunner.query(`
             CREATE OR REPLACE PROCEDURE polygon_parts.update_polygon_parts(
                 IN parts regclass,


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

this bug occures when an already ingested polygon part is modified manually.
it  was currently observed to influence the `ingestion_date_utc` field but it potentially applies to other columns as well.

it was discovered that the polygon parts update stored procedure referenced processed parts (already ingested) during the update process.
in this process affected polygon parts, that their ingestion_date_utc column was modified manually, overlapped by a new ingested part. these affected polygon parts referenced metadata stored in their original part as part of their update.

the fix mitigates this behavior by referencing the metadata already existing in the polygon part itself (before recreating it as the cause of the update). this demanded some other changes to the update stored procedure

an additional commit was added to remove a previous version of update stored procedure (having a different call signature) as part of maintenance