### PR TITLE
fix: aggregation (MAPCO-8298)

### DIFF
--- a/src/polygonParts/models/polygonPartsManager.ts
+++ b/src/polygonParts/models/polygonPartsManager.ts
@@ -283,9 +283,11 @@ export class PolygonPartsManager {
     const baseTable = filterQueryMetadata?.filterQueryAlias ?? polygonPartsEntityName.databaseObjectQualifiedName;
     const queryBuilder = filteredPolygonPartsQuery ?? entityManager.createQueryBuilder();
 
+    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+    const precision = Math.pow(10, -maxDecimalDigits);
     const footprintUnionCTE = entityManager
       .createQueryBuilder()
-      .select('st_union("polygon_part".footprint)', 'footprint_union')
+      .select(`st_union(st_reduceprecision("polygon_part".footprint, ${precision}), ${precision})`, 'footprint_union')
       .from(baseTable, 'polygon_part');
 
     const footprintSmoothCTE = entityManager

--- a/tests/integration/polygonParts/polygonParts.spec.ts
+++ b/tests/integration/polygonParts/polygonParts.spec.ts
@@ -158,7 +158,13 @@ describe('polygonParts', () => {
         expect(result.success).toBe(true);
         expect(result.data).toEqual(customAggregationNoFilter);
 
-        expect.assertions(4);
+        const coordinates = result.data?.geometry?.coordinates.flat(3) ?? [];
+        for (const coordinate of coordinates) {
+          const coordinatePrecision = coordinate.toString().split('.').at(1)?.length ?? 0;
+          expect(coordinatePrecision).toBeLessThanOrEqual(applicationConfig.aggregation.maxDecimalDigits);
+        }
+
+        expect.assertions(24);
       });
 
       it('should return 200 status code and filtered aggregated metadata with a valid feature collection filter (random data)', async () => {
@@ -241,10 +247,16 @@ describe('polygonParts', () => {
         expect(result.success).toBe(true);
         expect(result.data).toEqual(customAggregationWithFilter);
 
+        const coordinates = result.data?.geometry?.coordinates.flat(3) ?? [];
+        for (const coordinate of coordinates) {
+          const coordinatePrecision = coordinate.toString().split('.').at(1)?.length ?? 0;
+          expect(coordinatePrecision).toBeLessThanOrEqual(applicationConfig.aggregation.maxDecimalDigits);
+        }
+
         const isContained = booleanContains(filterBody.filter?.features[0].geometry as Geometry, result.data?.geometry as Geometry);
         expect(isContained).toBe(true);
 
-        expect.assertions(5);
+        expect.assertions(15);
       });
     });
 

--- a/tests/mocks/responseMocks.ts
+++ b/tests/mocks/responseMocks.ts
@@ -10,25 +10,25 @@ export const emptyFeature: AggregationLayerMetadataResponse = {
 export const customAggregationNoFilter: AggregationLayerMetadataResponse = {
   type: 'Feature',
   geometry: {
-    bbox: [34.851494459228, 31.764309584483, 35.231494406371, 32.305431896406],
+    bbox: [34.851494459228, 31.764309584482, 35.231494406372, 32.305431896406],
     type: 'MultiPolygon',
     coordinates: [
       [
         [
           [34.851494459228, 32.305431896406],
           [34.868241544701, 32.305431896406],
-          [34.868241544701, 32.294309584483],
-          [34.851494459228, 32.294309584483],
+          [34.868241544701, 32.294309584482],
+          [34.851494459228, 32.294309584482],
           [34.851494459228, 32.305431896406],
         ],
       ],
       [
         [
-          [35.210121597558, 31.782431896406],
-          [35.231494406371, 31.782431896406],
-          [35.231494406371, 31.764309584483],
-          [35.210121597558, 31.764309584483],
-          [35.210121597558, 31.782431896406],
+          [35.210121597557, 31.782431896406],
+          [35.231494406372, 31.782431896406],
+          [35.231494406372, 31.764309584482],
+          [35.210121597557, 31.764309584482],
+          [35.210121597557, 31.782431896406],
         ],
       ],
     ],
@@ -40,7 +40,7 @@ export const customAggregationNoFilter: AggregationLayerMetadataResponse = {
     imagingTimeEndUTC: new Date('2024-01-16T10:15:00+00:00'),
     maxResolutionMeter: 10.2,
     minResolutionMeter: 25.5,
-    productBoundingBox: '34.851494459228,31.764309584483,35.231494406371,32.305431896406',
+    productBoundingBox: '34.851494459228,31.764309584482,35.231494406372,32.305431896406',
     imagingTimeBeginUTC: new Date('2024-01-15T10:30:00+00:00'),
     maxHorizontalAccuracyCE90: 2.1,
     minHorizontalAccuracyCE90: 3.5,
@@ -50,15 +50,15 @@ export const customAggregationNoFilter: AggregationLayerMetadataResponse = {
 export const customAggregationWithFilter: AggregationLayerMetadataResponse = {
   type: 'Feature',
   geometry: {
-    bbox: [35.210121597558, 31.764309584483, 35.231494406371, 31.782431896406],
+    bbox: [35.210121597557, 31.764309584482, 35.231494406372, 31.782431896406],
     type: 'Polygon',
     coordinates: [
       [
-        [35.210121597558, 31.764309584483],
-        [35.210121597558, 31.782431896406],
-        [35.231494406371, 31.782431896406],
-        [35.231494406371, 31.764309584483],
-        [35.210121597558, 31.764309584483],
+        [35.210121597557, 31.764309584482],
+        [35.210121597557, 31.782431896406],
+        [35.231494406372, 31.782431896406],
+        [35.231494406372, 31.764309584482],
+        [35.210121597557, 31.764309584482],
       ],
     ],
   },
@@ -69,7 +69,7 @@ export const customAggregationWithFilter: AggregationLayerMetadataResponse = {
     imagingTimeEndUTC: new Date('2024-01-16T10:15:00+00:00'),
     maxResolutionMeter: 10.2,
     minResolutionMeter: 10.2,
-    productBoundingBox: '35.210121597558,31.764309584483,35.231494406371,31.782431896406',
+    productBoundingBox: '35.210121597557,31.764309584482,35.231494406372,31.782431896406',
     imagingTimeBeginUTC: new Date('2024-01-16T09:20:00+00:00'),
     maxHorizontalAccuracyCE90: 2.1,
     minHorizontalAccuracyCE90: 2.1,


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

changing aggregation calculation to reduce precision of the output footprint to precision determined by `maxDecimalDigits` configuration. this fixes an issue with st_union calculation