### PR TITLE
feat: add DELETE /polygonParts/{polygonPartsEntityName} endpoint (MAPCO-4750)

### DIFF
--- a/openapi3.yaml
+++ b/openapi3.yaml
@@ -133,6 +133,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorMessage'
+  /polygonParts/{polygonPartsEntityName}:
+    delete:
+      tags:
+        - polygon-parts
+      summary: Delete a polygon parts layer
+      description: >
+        Permanently drops the processed table, history table, and (if present)
+        validation table for the given polygon parts entity, within a single
+        database transaction. This operation is irreversible.
+      operationId: deletePolygonParts
+      parameters:
+        - in: path
+          name: polygonPartsEntityName
+          description: Polygon parts entity name
+          schema:
+            $ref: >-
+              ./SchemaRaster/core/polygon-parts.yaml#/components/schemas/PolygonPartsEntityName
+          required: true
+      responses:
+        '204':
+          description: No Content
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorMessage'
   /polygonParts/{polygonPartsEntityName}/find:
     post:
       tags:

--- a/src/polygonParts/controllers/interfaces.ts
+++ b/src/polygonParts/controllers/interfaces.ts
@@ -84,3 +84,10 @@ export type ValidationEntityQuery = Pick<CommonRecord, 'productId' | 'productTyp
 
 export type ProcessPolygonPartsRequestBody = Pick<CommonRecord, 'productId' | 'productType'> &
   Pick<ProcessPolygonPartsOptions, 'shouldClearEntities'>;
+
+/**
+ * Delete polygon parts params
+ */
+export interface DeletePolygonPartsParams {
+  readonly polygonPartsEntityName: EntityIdentifier;
+}

--- a/src/polygonParts/controllers/polygonPartsController.ts
+++ b/src/polygonParts/controllers/polygonPartsController.ts
@@ -7,6 +7,7 @@ import type {
   AggregatePolygonPartsRequestBody,
   AggregationLayerMetadataParams,
   AggregationLayerMetadataResponseBody,
+  DeletePolygonPartsParams,
   ExistsRequestBody,
   ExistsResponseBody,
   FindPolygonPartsParams,
@@ -73,6 +74,8 @@ export type ValidatePolygonPartsHandler = RequestHandler<
 >;
 
 export type DeleteValidationPolygonPartsEntityHandler = RequestHandler<undefined, undefined, undefined, ValidationEntityQuery, EntitiesMetadata>;
+
+export type DeletePolygonPartsHandler = RequestHandler<DeletePolygonPartsParams, undefined, undefined, undefined, EntitiesMetadata>;
 
 export type ProcessPolygonPartsEntityHandler = RequestHandler<undefined, undefined, ProcessPolygonPartsRequestBody, undefined, EntitiesMetadata>;
 
@@ -170,6 +173,15 @@ export class PolygonPartsController {
     try {
       const { shouldClearEntities = false } = req.body;
       await this.polygonPartsManager.process({ entitiesMetadata: res.locals, shouldClearEntities });
+      return res.status(httpStatus.NO_CONTENT).send();
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  public deletePolygonParts: DeletePolygonPartsHandler = async (req, res, next) => {
+    try {
+      await this.polygonPartsManager.deletePolygonParts(res.locals);
       return res.status(httpStatus.NO_CONTENT).send();
     } catch (error) {
       next(error);

--- a/src/polygonParts/controllers/transformerController.ts
+++ b/src/polygonParts/controllers/transformerController.ts
@@ -15,6 +15,7 @@ import type {
 } from './interfaces';
 import type {
   AggregationLayerMetadataHandler,
+  DeletePolygonPartsHandler,
   DeleteValidationPolygonPartsEntityHandler,
   ValidatePolygonPartsHandler,
 } from './polygonPartsController';
@@ -152,6 +153,17 @@ export class TransformerController {
       res.locals = entitiesMetadata;
       next();
     } catch (error) {
+      next(error);
+    }
+  };
+
+  public readonly parseDeletePolygonParts: DeletePolygonPartsHandler = (req, res, next) => {
+    try {
+      const entitiesMetadata = this.transformer.parseEntitiesMetadata(req.params);
+      res.locals = entitiesMetadata;
+      next();
+    } catch (error) {
+      this.logger.error({ msg: 'delete polygon parts transformer failed', err: error });
       next(error);
     }
   };

--- a/src/polygonParts/controllers/validationsController.ts
+++ b/src/polygonParts/controllers/validationsController.ts
@@ -160,4 +160,17 @@ export class ValidationsController {
       next(error);
     }
   };
+
+  public readonly validateDeletePolygonParts: RequestHandler<unknown, undefined, undefined, undefined> = (req, _, next) => {
+    try {
+      this.validator.schemaParser({ schema: polygonPartsEntityNameSchema, value: req.params, errorMessagePrefix: 'Invalid request params' });
+      next();
+    } catch (error) {
+      this.logger.error({ msg: 'delete polygon parts validation failed', err: error });
+      if (error instanceof ValidationError) {
+        return next(new BadRequestError(error.message));
+      }
+      next(error);
+    }
+  };
 }

--- a/src/polygonParts/models/polygonPartsManager.ts
+++ b/src/polygonParts/models/polygonPartsManager.ts
@@ -427,7 +427,7 @@ export class PolygonPartsManager {
     } = entitiesMetadata.entitiesNames;
 
     const logger = this.logger.child({ polygonPartsEntityName });
-    logger.info({ msg: 'deleting polygon parts layer', polygonPartsEntityName });
+    logger.info({ msg: 'deleting polygon parts layer' });
 
     try {
       await this.connectionManager.getDataSource().transaction(async (entityManager) => {
@@ -438,7 +438,9 @@ export class PolygonPartsManager {
           throw new NotFoundError(`Table with the name '${polygonPartsEntityName}' doesn't exists`);
         }
 
+        logger.info({ msg: 'dropping polygon parts table', tableName: polygonPartsQualifiedName });
         await entityManager.query(`DROP TABLE ${polygonPartsQualifiedName}`);
+        logger.info({ msg: 'dropping history table', tableName: historyQualifiedName });
         await entityManager.query(`DROP TABLE ${historyQualifiedName}`);
         const validationExists = await this.connectionManager.entityExists(entityManager, validationsEntityName);
         if (validationExists) {

--- a/src/polygonParts/models/polygonPartsManager.ts
+++ b/src/polygonParts/models/polygonPartsManager.ts
@@ -423,7 +423,7 @@ export class PolygonPartsManager {
     const {
       polygonParts: { entityName: polygonPartsEntityName, databaseObjectQualifiedName: polygonPartsQualifiedName },
       history: { databaseObjectQualifiedName: historyQualifiedName },
-      validations: { databaseObjectQualifiedName: validationsQualifiedName },
+      validations: { entityName: validationsEntityName, databaseObjectQualifiedName: validationsQualifiedName },
     } = entitiesMetadata.entitiesNames;
 
     const logger = this.logger.child({ polygonPartsEntityName });
@@ -440,7 +440,10 @@ export class PolygonPartsManager {
 
         await entityManager.query(`DROP TABLE ${polygonPartsQualifiedName}`);
         await entityManager.query(`DROP TABLE ${historyQualifiedName}`);
-        await entityManager.query(`DROP TABLE IF EXISTS ${validationsQualifiedName}`);
+        const validationExists = await this.connectionManager.entityExists(entityManager, validationsEntityName);
+        if (validationExists) {
+          await deleteValidationsTable(entityManager, this.schema, validationsEntityName, validationsQualifiedName, logger);
+        }
       });
     } catch (error) {
       const errorMessage = 'Delete polygon parts transaction failed';

--- a/src/polygonParts/models/polygonPartsManager.ts
+++ b/src/polygonParts/models/polygonPartsManager.ts
@@ -435,7 +435,7 @@ export class PolygonPartsManager {
 
         const entityExists = await this.connectionManager.entityExists(entityManager, polygonPartsEntityName);
         if (!entityExists) {
-          throw new NotFoundError(`Table with the name '${polygonPartsEntityName}' doesn't exists`);
+          throw new NotFoundError(`Table with the name '${polygonPartsEntityName}' doesn't exist`);
         }
 
         logger.info({ msg: 'dropping polygon parts table', tableName: polygonPartsQualifiedName });

--- a/src/polygonParts/models/polygonPartsManager.ts
+++ b/src/polygonParts/models/polygonPartsManager.ts
@@ -419,6 +419,36 @@ export class PolygonPartsManager {
     }
   }
 
+  public async deletePolygonParts(entitiesMetadata: EntitiesMetadata): Promise<void> {
+    const {
+      polygonParts: { entityName: polygonPartsEntityName, databaseObjectQualifiedName: polygonPartsQualifiedName },
+      history: { databaseObjectQualifiedName: historyQualifiedName },
+      validations: { databaseObjectQualifiedName: validationsQualifiedName },
+    } = entitiesMetadata.entitiesNames;
+
+    const logger = this.logger.child({ polygonPartsEntityName });
+    logger.info({ msg: 'deleting polygon parts layer', polygonPartsEntityName });
+
+    try {
+      await this.connectionManager.getDataSource().transaction(async (entityManager) => {
+        await entityManager.query(`SET search_path TO ${this.schema},public`);
+
+        const entityExists = await this.connectionManager.entityExists(entityManager, polygonPartsEntityName);
+        if (!entityExists) {
+          throw new NotFoundError(`Table with the name '${polygonPartsEntityName}' doesn't exists`);
+        }
+
+        await entityManager.query(`DROP TABLE ${polygonPartsQualifiedName}`);
+        await entityManager.query(`DROP TABLE ${historyQualifiedName}`);
+        await entityManager.query(`DROP TABLE IF EXISTS ${validationsQualifiedName}`);
+      });
+    } catch (error) {
+      const errorMessage = 'Delete polygon parts transaction failed';
+      logger.error({ msg: errorMessage, err: error });
+      throw error;
+    }
+  }
+
   public async process(options: ProcessPolygonPartsOptions): Promise<void> {
     const { entitiesMetadata, shouldClearEntities = false } = options;
     const {

--- a/src/polygonParts/routes/polygonPartsRouter.ts
+++ b/src/polygonParts/routes/polygonPartsRouter.ts
@@ -10,6 +10,12 @@ const polygonPartsRouterFactory: FactoryFunction<Router> = (dependencyContainer)
   const validations = dependencyContainer.resolve(ValidationsController);
   const transformer = dependencyContainer.resolve(TransformerController);
 
+  router.delete(
+    '/:polygonPartsEntityName',
+    validations.validateDeletePolygonParts,
+    transformer.parseDeletePolygonParts,
+    controller.deletePolygonParts
+  );
   router.post('/:polygonPartsEntityName/find', validations.validateFindPolygonParts, transformer.parseFindPolygonParts, controller.findPolygonParts);
   router.post(
     '/:polygonPartsEntityName/aggregate',

--- a/src/polygonParts/routes/polygonPartsRouter.ts
+++ b/src/polygonParts/routes/polygonPartsRouter.ts
@@ -10,6 +10,7 @@ const polygonPartsRouterFactory: FactoryFunction<Router> = (dependencyContainer)
   const validations = dependencyContainer.resolve(ValidationsController);
   const transformer = dependencyContainer.resolve(TransformerController);
 
+  router.delete('/validate', transformer.parseDeleteValidationPolygonPartsEntity, controller.deleteValidationPolygonParts);
   router.delete(
     '/:polygonPartsEntityName',
     validations.validateDeletePolygonParts,
@@ -33,7 +34,6 @@ const polygonPartsRouterFactory: FactoryFunction<Router> = (dependencyContainer)
   router.post('/', validations.validateCreatePolygonParts, transformer.parseCreatePolygonParts, controller.createPolygonParts);
   router.put('/', validations.validateUpdatePolygonParts, transformer.parseUpdatePolygonParts, controller.updatePolygonParts);
   router.post('/validate', transformer.parseValidatePolygonParts, controller.validatePolygonParts);
-  router.delete('/validate', transformer.parseDeleteValidationPolygonPartsEntity, controller.deleteValidationPolygonParts);
   router.put('/process', transformer.parseProcessPolygonParts, controller.process);
 
   return router;

--- a/tests/integration/polygonParts/delete.spec.ts
+++ b/tests/integration/polygonParts/delete.spec.ts
@@ -1,0 +1,128 @@
+import { faker } from '@faker-js/faker';
+import { jsLogger } from '@map-colonies/js-logger';
+import { trace } from '@opentelemetry/api';
+import { StatusCodes as httpStatusCodes } from 'http-status-codes';
+import { container } from 'tsyringe';
+import { type DataSourceOptions } from 'typeorm';
+import { getApp } from '../../../src/app';
+import { ConnectionManager } from '../../../src/common/connectionManager';
+import { SERVICES } from '../../../src/common/constants';
+import type { DbConfig } from '../../../src/common/interfaces';
+import { createConnectionOptions } from '../../../src/common/utils';
+import { Transformer } from '../../../src/middlewares/transformer';
+import { History } from '../../../src/polygonParts/DAL/history';
+import { PolygonPart } from '../../../src/polygonParts/DAL/polygonPart';
+import { namingStrategy } from '../../../src/polygonParts/DAL/utils';
+import { ValidatePart } from '../../../src/polygonParts/DAL/validationPart';
+import { getConfigForTests, initConfigForTests } from '../../configurations/config';
+import { HelperDB } from './helpers/db';
+import { PolygonPartsRequestSender } from './helpers/requestSender';
+import type { GetEntitiesMetadata } from './helpers/types';
+import { ingestPolygonParts } from './helpers/utils';
+
+let testDataSourceOptions: DataSourceOptions;
+
+const seed = process.env.TEST_SEED ?? Math.floor(Math.random() * 1000000);
+faker.seed(Number(seed));
+console.info(`Test seed: ${seed}`);
+
+describe('delete', () => {
+  let requestSender: PolygonPartsRequestSender;
+  let helperDB: HelperDB;
+  let getEntitiesMetadata: GetEntitiesMetadata;
+
+  beforeAll(async () => {
+    await initConfigForTests();
+    const dbConfig = getConfigForTests().get<Required<DbConfig>>('db');
+    const { schema } = dbConfig;
+    testDataSourceOptions = {
+      entities: [History, PolygonPart, ValidatePart],
+      namingStrategy,
+      ...createConnectionOptions(dbConfig),
+    };
+    helperDB = new HelperDB(testDataSourceOptions, schema);
+    await helperDB.initConnection();
+  });
+
+  afterAll(async () => {
+    try {
+      await helperDB.destroyConnection();
+    } catch (error) {
+      console.error('Error destroying helperDB connection:', error);
+    }
+  });
+
+  beforeEach(async () => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+
+    await helperDB.createSchema();
+    await helperDB.sync();
+
+    container.clearInstances();
+
+    const [app] = await getApp({
+      override: [
+        { token: SERVICES.LOGGER, provider: { useValue: await jsLogger({ enabled: false }) } },
+        { token: SERVICES.TRACER, provider: { useValue: trace.getTracer('testTracer') } },
+      ],
+      useChild: true,
+    });
+
+    getEntitiesMetadata = container.resolve(Transformer).getEntitiesMetadata;
+    requestSender = new PolygonPartsRequestSender(app);
+  });
+
+  afterEach(async () => {
+    const connectionManager = container.resolve<ConnectionManager>(ConnectionManager);
+    await connectionManager.destroy();
+    await helperDB.dropSchema();
+    jest.restoreAllMocks();
+  });
+
+  describe('DELETE /polygonParts/:polygonPartsEntityName', () => {
+    describe('Bad Path', () => {
+      it('should return 404 when the entity does not exist', async () => {
+        const response = await requestSender.deletePolygonParts('doesnotexist_orthophoto');
+
+        expect(response.status).toBe(httpStatusCodes.NOT_FOUND);
+        expect(response).toSatisfyApiSpec();
+      });
+    });
+
+    describe('Happy Path', () => {
+      it('should return 204 and drop all three tables when the entity exists', async () => {
+        const { entityIdentifier } = await ingestPolygonParts({
+          input: {},
+          getEntitiesMetadata,
+          requestSender,
+        });
+
+        const { entitiesNames } = getEntitiesMetadata({ polygonPartsEntityName: entityIdentifier });
+
+        const response = await requestSender.deletePolygonParts(entityIdentifier);
+
+        expect(response.status).toBe(httpStatusCodes.NO_CONTENT);
+        expect(response).toSatisfyApiSpec();
+
+        await expect(helperDB.tableExists(entitiesNames.polygonParts.entityName)).resolves.toBe(false);
+        await expect(helperDB.tableExists(entitiesNames.history.entityName)).resolves.toBe(false);
+        await expect(helperDB.tableExists(entitiesNames.validations.entityName)).resolves.toBe(false);
+      });
+
+      it('should return 404 on a second delete of the same entity', async () => {
+        const { entityIdentifier } = await ingestPolygonParts({
+          input: {},
+          getEntitiesMetadata,
+          requestSender,
+        });
+
+        await requestSender.deletePolygonParts(entityIdentifier);
+        const response = await requestSender.deletePolygonParts(entityIdentifier);
+
+        expect(response.status).toBe(httpStatusCodes.NOT_FOUND);
+        expect(response).toSatisfyApiSpec();
+      });
+    });
+  });
+});

--- a/tests/integration/polygonParts/delete.spec.ts
+++ b/tests/integration/polygonParts/delete.spec.ts
@@ -1,4 +1,3 @@
-import { faker } from '@faker-js/faker';
 import { jsLogger } from '@map-colonies/js-logger';
 import { trace } from '@opentelemetry/api';
 import { StatusCodes as httpStatusCodes } from 'http-status-codes';
@@ -21,10 +20,6 @@ import type { GetEntitiesMetadata } from './helpers/types';
 import { ingestPolygonParts } from './helpers/utils';
 
 let testDataSourceOptions: DataSourceOptions;
-
-const seed = process.env.TEST_SEED ?? Math.floor(Math.random() * 1000000);
-faker.seed(Number(seed));
-console.info(`Test seed: ${seed}`);
 
 describe('delete', () => {
   let requestSender: PolygonPartsRequestSender;

--- a/tests/integration/polygonParts/delete.spec.ts
+++ b/tests/integration/polygonParts/delete.spec.ts
@@ -119,5 +119,19 @@ describe('delete', () => {
         expect(response).toSatisfyApiSpec();
       });
     });
+
+    describe('Route precedence with DELETE /polygonParts/validate', () => {
+      // Guards against route shadowing: the static DELETE /polygonParts/validate must take
+      // precedence over the parameterized DELETE /polygonParts/:polygonPartsEntityName. If the
+      // parameterized route captured `validate`, the request would reach deletePolygonParts and
+      // return 404 (no such table). Instead it must reach the validate-delete handler, whose
+      // contract rejects the missing query params with 400 — as seen in the PR review example.
+      it('should route DELETE /polygonParts/validate to the validate-delete handler (400), not entity delete (404)', async () => {
+        const response = await requestSender.deletePolygonParts('validate');
+
+        expect(response.status).toBe(httpStatusCodes.BAD_REQUEST);
+        expect(response).toSatisfyApiSpec();
+      });
+    });
   });
 });

--- a/tests/integration/polygonParts/helpers/requestSender.ts
+++ b/tests/integration/polygonParts/helpers/requestSender.ts
@@ -66,6 +66,10 @@ export class PolygonPartsRequestSender {
     return agent(this.app).delete('/polygonParts/validate').query(query).send();
   }
 
+  public async deletePolygonParts(polygonPartsEntityName: string): Promise<Response> {
+    return agent(this.app).delete(`/polygonParts/${polygonPartsEntityName}`).send();
+  }
+
   public async moveValidationsToHistory(query: ValidationEntityQuery): Promise<Response> {
     return agent(this.app).put('/history').query(query).send();
   }


### PR DESCRIPTION
## Summary

- Adds `DELETE /polygonParts/{polygonPartsEntityName}` to decommission a polygon-parts layer
- Atomically drops the processed table (`{entity}`), history table (`{entity}_history`), and validation table (`{entity}_validation_parts` — `IF EXISTS`) in a single transaction
- Returns `204 No Content` on success; `404 Not Found` if the entity does not exist
- OpenAPI spec (`openapi3.yaml`) updated with the new operation

## Implementation

- **Route**: `DELETE /:polygonPartsEntityName` in the polygon-parts router, using the existing transformer middleware to resolve entity names
- **Validation**: `validateDeletePolygonParts` validates the path param against `polygonPartsEntityNameSchema` (same as `find`/`aggregate`/`intersection`)
- **Manager**: `deletePolygonParts` — checks entity existence, then drops all three tables in one transaction

## Test plan

- [ ] `DELETE /polygonParts/{polygonPartsEntityName}` returns `204` and all three tables are gone after a successful ingestion
- [ ] Second delete on the same entity returns `404`
- [ ] Delete on a non-existent (but valid-format) entity name returns `404`
- [ ] All responses satisfy the OpenAPI spec (`toSatisfyApiSpec()`)
- [ ] Full integration suite passes sequentially (`--runInBand`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)