### PR TITLE
fix(deps): upgrade @map-colonies/raster-shared to ^8.3.0 (MAPCO-11282)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@map-colonies/mc-utils": "^6.0.0",
         "@map-colonies/openapi-express-viewer": "^5.0.0",
         "@map-colonies/prometheus": "^1.0.0",
-        "@map-colonies/raster-shared": "^8.1.0",
+        "@map-colonies/raster-shared": "^8.3.0",
         "@map-colonies/read-pkg": "^1.0.0",
         "@map-colonies/schemas": "^1.18.0",
         "@map-colonies/tracing": "^1.0.0",
@@ -2358,9 +2358,9 @@
       }
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.1.0.tgz",
-      "integrity": "sha512-D/otgsJ7X00NnxlMJUSuj6rC9U779ReZDe4pAmtGsIOuQvASRnjjKIGIj/9nFJth6lbOaptppp0RRGImGd0jIw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0.tgz",
+      "integrity": "sha512-5faR0iBC9Dpxm7Z8fY+3d+5oolHqVk/urXeOq3nHuIEMOvwRT2TrTr9fmt6TK8DaCjyQXBeEU1nijvuPLHmrEw==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@map-colonies/mc-utils": "^6.0.0",
     "@map-colonies/openapi-express-viewer": "^5.0.0",
     "@map-colonies/prometheus": "^1.0.0",
-    "@map-colonies/raster-shared": "^8.1.0",
+    "@map-colonies/raster-shared": "^8.3.0",
     "@map-colonies/read-pkg": "^1.0.0",
     "@map-colonies/schemas": "^1.18.0",
     "@map-colonies/tracing": "^1.0.0",


### PR DESCRIPTION
## Summary
MAPCO-11282 — upgrade `@map-colonies/raster-shared` to the official **v8.3.0** release.

`^8.1.0` → `^8.3.0` (a two-minor jump — the largest of the six)

